### PR TITLE
enable lanching vnc with a user account

### DIFF
--- a/novnc_rocker/novnc.py
+++ b/novnc_rocker/novnc.py
@@ -45,7 +45,7 @@ class NoVNC(RockerExtension):
         return em.expand(snippet, self._env_subs)
 
     def get_docker_args(self, cli_args):
-        return '-p %s:%s' % (cli_args['novnc_port'], cli_args['novnc_port'])
+        return ' -p %s:%s' % (cli_args['novnc_port'], cli_args['novnc_port'])
 
     @staticmethod
     def register_arguments(parser, defaults={}):

--- a/novnc_rocker/templates/turbovnc.conf
+++ b/novnc_rocker/templates/turbovnc.conf
@@ -1,3 +1,0 @@
-[program:turbovnc]
-command=/opt/TurboVNC/bin/vncserver  -SecurityTypes None -fg -nohttpd -geometry 1920x1080
-autorestart=true

--- a/novnc_rocker/templates/turbovnc.conf.em
+++ b/novnc_rocker/templates/turbovnc.conf.em
@@ -1,0 +1,5 @@
+[program:turbovnc]
+command=/opt/TurboVNC/bin/vncserver  -SecurityTypes None -fg -nohttpd -geometry 1280x720
+autorestart=true
+user=@(vnc_user)
+environment=USER="@(vnc_user)",HOME="@(vnc_user_home)"

--- a/novnc_rocker/templates/turbovnc.conf.em
+++ b/novnc_rocker/templates/turbovnc.conf.em
@@ -2,4 +2,4 @@
 command=/opt/TurboVNC/bin/vncserver  -SecurityTypes None -fg -nohttpd -geometry 1280x720
 autorestart=true
 user=@(vnc_user)
-environment=USER="@(vnc_user)",HOME="@(vnc_user_home)",TVNC_WM="lxqt-session"
+environment=USER="@(vnc_user)",HOME="@(vnc_user_home)",TVNC_WM="x-session-manager"

--- a/novnc_rocker/templates/turbovnc.conf.em
+++ b/novnc_rocker/templates/turbovnc.conf.em
@@ -2,4 +2,4 @@
 command=/opt/TurboVNC/bin/vncserver  -SecurityTypes None -fg -nohttpd -geometry 1280x720
 autorestart=true
 user=@(vnc_user)
-environment=USER="@(vnc_user)",HOME="@(vnc_user_home)"
+environment=USER="@(vnc_user)",HOME="@(vnc_user_home)",TVNC_WM="lxqt-session"

--- a/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
+++ b/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
@@ -17,12 +17,19 @@ RUN cd /tmp && \
     && dpkg -i *.deb \
     && rm -f /tmp/*.deb
 
-RUN mkdir -p /root/.vnc
-RUN echo testpass | /opt/TurboVNC/bin/vncpasswd -f > /root/.vnc/passwd && chmod 600 /root/.vnc/passwd
+RUN echo '$vncUserDir = "@(vnc_user_home)";' >> /etc/turbovncserver.conf
+# TODO(tfoote) authentication
+# RUN mkdir -p ~/@(vnc_user)-vnc
+# RUN echo testpass | /opt/TurboVNC/bin/vncpasswd -f > ~/@(vnc_user)-vnc/passwd && chmod -R 600 ~/@(vnc_user)-vnc/passwd
+# TODO(tfoote) needed maybe too? && chown -R @(vnc_user) /tmp/@(vnc_user)-vnc/passwd
+
+# Avoid a warning about needing to be owned by root
+RUN mkdir -p /tmp/.X11-unix && chmod 0777 /tmp/.X11-unix
 
 RUN mkdir -p /root/.supervisor/conf.d
 
 COPY supervisor.conf /root/.supervisor
 COPY turbovnc.conf /root/.supervisor/conf.d
 
-CMD /usr/bin/supervisord -c /root/.supervisor/supervisor.conf
+
+CMD @(vnc_user != 'root' ? 'sudo ' ! '')@ /usr/bin/supervisord -c /root/.supervisor/supervisor.conf

--- a/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
+++ b/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
@@ -24,9 +24,6 @@ RUN echo '$vncUserDir = "/tmp/@(vnc_user)-vnc";' >> /etc/turbovncserver.conf
 # RUN echo testpass | /opt/TurboVNC/bin/vncpasswd -f > ~/@(vnc_user)-vnc/passwd && chmod -R 600 ~/@(vnc_user)-vnc/passwd
 # TODO(tfoote) needed maybe too? && chown -R @(vnc_user) /tmp/@(vnc_user)-vnc/passwd
 
-# Avoid a warning about needing to be owned by root
-RUN mkdir -p /tmp/.X11-unix && chmod 0777 /tmp/.X11-unix
-
 RUN mkdir -p /root/.supervisor/conf.d
 
 COPY supervisor.conf /root/.supervisor

--- a/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
+++ b/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
@@ -17,9 +17,10 @@ RUN cd /tmp && \
     && dpkg -i *.deb \
     && rm -f /tmp/*.deb
 
-RUN echo '$vncUserDir = "@(vnc_user_home)";' >> /etc/turbovncserver.conf
+# Keep vnc content out of
+RUN echo '$vncUserDir = "/tmp/@(vnc_user)-vnc";' >> /etc/turbovncserver.conf
+
 # TODO(tfoote) authentication
-# RUN mkdir -p ~/@(vnc_user)-vnc
 # RUN echo testpass | /opt/TurboVNC/bin/vncpasswd -f > ~/@(vnc_user)-vnc/passwd && chmod -R 600 ~/@(vnc_user)-vnc/passwd
 # TODO(tfoote) needed maybe too? && chown -R @(vnc_user) /tmp/@(vnc_user)-vnc/passwd
 

--- a/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
+++ b/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
@@ -15,8 +15,7 @@ RUN cd /tmp && \
     curl -fsSL -O ${SOURCEFORGE}/turbovnc/files/${TURBOVNC_VERSION}/turbovnc_${TURBOVNC_VERSION}_amd64.deb \
         -O ${SOURCEFORGE}/virtualgl/files/${VIRTUALGL_VERSION}/virtualgl_${VIRTUALGL_VERSION}_amd64.deb \
     && dpkg -i *.deb \
-    && rm -f /tmp/*.deb \
-    && sed -i 's/$host:/unix:/g' /opt/TurboVNC/bin/vncserver
+    && rm -f /tmp/*.deb
 
 RUN mkdir -p /root/.vnc
 RUN echo testpass | /opt/TurboVNC/bin/vncpasswd -f > /root/.vnc/passwd && chmod 600 /root/.vnc/passwd

--- a/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
+++ b/novnc_rocker/templates/turbovnc_snippet.Dockerfile.em
@@ -19,6 +19,9 @@ RUN cd /tmp && \
 
 # Keep vnc content out of
 RUN echo '$vncUserDir = "/tmp/@(vnc_user)-vnc";' >> /etc/turbovncserver.conf
+# One less file in home to avoid cluttering the home directory
+ENV XAUTHORITY "/tmp/@(vnc_user)-vnc/.Xauthority"
+# RUN echo '$xstartup = "/tmp/@(vnc_user)-vnc/xstartup.turbovnc;' >> /etc/turbovncserver.conf
 
 # TODO(tfoote) authentication
 # RUN echo testpass | /opt/TurboVNC/bin/vncpasswd -f > ~/@(vnc_user)-vnc/passwd && chmod -R 600 ~/@(vnc_user)-vnc/passwd
@@ -29,5 +32,17 @@ RUN mkdir -p /root/.supervisor/conf.d
 COPY supervisor.conf /root/.supervisor
 COPY turbovnc.conf /root/.supervisor/conf.d
 
+## Make sure we're in lxqt. gnome-session will win if it's installed in the image.
+RUN update-alternatives --set x-session-manager /usr/bin/startlxqt
+
+# TODO(tfoote) avoid selecting mutter vs openbox windows manager
+
+# Disable unneeded modules
+
+RUN echo 'Hidden=True' >> /etc/xdg/autostart/lxqt-xscreensaver-autostart.desktop
+RUN echo 'Hidden=True' >> /etc/xdg/autostart/lxqt-powermanagement.desktop
+RUN echo 'Hidden=True' >> /etc/xdg/autostart/upg-notifier-autostart.desktop
+RUN echo 'Hidden=True' >> /etc/xdg/autostart/nm-tray-autostart.desktop
+RUN echo 'Hidden=True' >> /etc/xdg/autostart/nm-applet.desktop
 
 CMD @(vnc_user != 'root' ? 'sudo ' ! '')@ /usr/bin/supervisord -c /root/.supervisor/supervisor.conf

--- a/novnc_rocker/turbovnc.py
+++ b/novnc_rocker/turbovnc.py
@@ -26,8 +26,8 @@ class TurboVNC(RockerExtension):
             self._env_subs['vnc_user_home'] = '/root'
             if 'user' in cli_args:
                 if cli_args['user']:
-                    self._env_subs['vnc_user'] = getpass.getuser()
-                    self._env_subs['vnc_user_home'] = os.path.expanduser('~')
+                    self._env_subs['vnc_user'] = cli_args['user_override_name'] if cli_args['user_override_name'] else getpass.getuser()
+                    self._env_subs['vnc_user_home'] = os.path.join('/home/', cli_args['user_override_name']) if cli_args['user_override_name'] else os.path.expanduser('~')
         return self._env_subs
 
     def precondition_environment(self, cli_args):

--- a/novnc_rocker/turbovnc.py
+++ b/novnc_rocker/turbovnc.py
@@ -1,4 +1,6 @@
 import em
+import getpass
+import os
 import pkgutil
 import sys
 from rocker.extensions import RockerExtension, name_to_argument
@@ -14,6 +16,19 @@ class TurboVNC(RockerExtension):
         self._env_subs = {}
         self.name = TurboVNC.get_name()
         self.SUPPORTED_CODENAMES = ['focal']
+
+    def compute_env_subs(self, cli_args):
+        # TODO(tfoote) this caches cli_args implicitly
+        if not self._env_subs:
+            # default case
+            # Todo evaluate elsewhere?
+            self._env_subs['vnc_user'] = 'root'
+            self._env_subs['vnc_user_home'] = '/root'
+            if 'user' in cli_args:
+                if cli_args['user']:
+                    self._env_subs['vnc_user'] = getpass.getuser()
+                    self._env_subs['vnc_user_home'] = os.path.expanduser('~')
+        return self._env_subs
 
     def precondition_environment(self, cli_args):
         detected_os = detect_os(cli_args['base_image'], print, nocache=cli_args.get('nocache', False))
@@ -32,19 +47,35 @@ class TurboVNC(RockerExtension):
         return ''
 
     def get_files(self, cli_args):
-        file_list = ['supervisor.conf', 'turbovnc.conf']
+        file_list = ['supervisor.conf']
         files = {}
         for f in file_list:
             files['%s' % f] = pkgutil.get_data(
                 'novnc_rocker',
                 'templates/%s' % f).decode('utf-8')
+        template_list = ['turbovnc.conf']
+        self.compute_env_subs(cli_args)
+        for f in template_list:
+            try:
+                files['%s' % f] = em.expand(
+                    pkgutil.get_data(
+                    'novnc_rocker',
+                    'templates/%s.em' % f).decode('utf-8'),
+                    self._env_subs)
+            except (NameError, TypeError) as ex:
+                raise NameError("Failed to evaluate template %s: %s \args are: %s" % (f, ex, self._env_subs))
         return files
 
     def get_snippet(self, cli_args):
+        self.compute_env_subs(cli_args)
         snippet = pkgutil.get_data(
             'novnc_rocker',
             'templates/%s_snippet.Dockerfile.em' % self.name).decode('utf-8')
-        return em.expand(snippet, self._env_subs)
+        try:
+            result = em.expand(snippet, self._env_subs)
+        except (NameError, TypeError) as ex:
+            raise NameError("Failed to evaluate snippet for %s: %s. \nargs are: %s" % (self.name, ex, self._env_subs))
+        return result
 
     def get_docker_args(self, cli_args):
         return ''


### PR DESCRIPTION
This allows a more common user experience with a non-root user. You can use the usual --user and --home extensions.